### PR TITLE
Remove base64 encoding and add dynamic base_url PLAT-302

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -7,7 +7,7 @@ router = OptionalSlashRouter()
 router.register(r'documents', DocumentViewSet)
 
 urlpatterns = [
-    re_path(r'^file/(?P<id>\w+)/$', document_download_view),
+    re_path(r'^file/(?P<id>\w+)/$', document_download_view, name='document-file'),
     re_path(r'^thumbnail/(?P<id>\w+)/$', document_thumbnail_view),
 ]
 

--- a/documents/tests/test_serializers.py
+++ b/documents/tests/test_serializers.py
@@ -55,7 +55,7 @@ class DocumentSerializerTest(TestCase):
         self.document = mfactories.Document(file_name='Document1.pdf',
                                             file=file_mock)
 
-        expected_file = "/documents/file/{}/".format(self.document.pk)
+        expected_file = "/file/{}/".format(self.document.pk)
 
         serializer = DocumentSerializer(instance=self.document)
         self.assertEquals(serializer.data['file'], expected_file)


### PR DESCRIPTION
## Purpose
We were using base64 binary-to-text encoding scheme in "documents" service. It increases the file size once we decode the service. 

## Approach
Removed `Base64FileField` from `DocumentSerializer` and added a solution similar to the `products_service`.

By the way, the hard-coded `base_url` could be rewritten to be adapted to the path of the endpoint set in bifrost through the passed request.

https://humanitec.atlassian.net/browse/PLAT-302